### PR TITLE
Docs: Add deprecation warning to Online Docs mentioning `gen_statem`

### DIFF
--- a/lib/connection.ex
+++ b/lib/connection.ex
@@ -2,6 +2,20 @@ defmodule Connection do
   @moduledoc ~S"""
   A behaviour module for implementing connection processes.
 
+  > #### Deprecation Warning {: .warning}
+  >
+  > With the inclusion of [`gen_statem`](https://www.erlang.org/doc/man/gen_statem.html)
+  in Erlang/OTP, this project is no longer necessary.
+  >
+  > See the following pull request as examples
+  of replacing `Connection` by `gen_statem` in existing projects:
+  >   * https://github.com/elixir-ecto/postgrex/pull/643
+  >   * https://github.com/elixir-ecto/postgrex/pull/644
+  >   * https://github.com/elixir-ecto/db_connection/pull/275
+  >
+  > We may release new versions if necessary to keep compatibility with Erlang/OTP and
+  Elixir but otherwise this package is no longer recommended for new projects.
+
   The `Connection` behaviour is a superset of the `GenServer` behaviour. The
   additional return values and callbacks are designed to aid building a
   connection process that can handle a peer being (temporarily) unavailable.


### PR DESCRIPTION
We've updated the `README.md` to recommend `gen_statem` as an alternative to this `Connection` module, but users visiting the module via the [Online Documentation](https://hexdocs.pm/connection/Connection.html) may miss that note, so it may be a good idea to have that note in there too.

This PR adds that same note as a `deprecation warning` to the `@moduledoc` itself.

This is what the updated docs look like with this update:

![Screenshot 2024-04-26 at 1 31 59 AM](https://github.com/elixir-ecto/connection/assets/5550692/2403b064-8dcf-431e-bf0e-d34b46a457a7)